### PR TITLE
fixed map ordering

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -7,3 +7,8 @@
   font-family: "Open Sans", sans-serif;
   padding: 0;
 }
+
+.map-sticky {
+  position: sticky;
+  top: 0px;
+}

--- a/app/views/studios/index.html.erb
+++ b/app/views/studios/index.html.erb
@@ -14,7 +14,9 @@
       <% end %>
     </div>
   </div>
-  <div class="container-fluid mt-4 mr-5 pr-5 sticky-top" id="sidebar"
+  <%# Note: the map uses a custom map-sticky instead of the bootstrap one,
+  because the bootstrap sticky has a z-index on top of the avatar dropdown %>
+  <div class="container-fluid mt-4 mr-5 pr-5 map-sticky" id="sidebar"
     data-controller="mapbox"
     data-mapbox-markers-value="<%= @markers.to_json %>"
     data-mapbox-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"


### PR DESCRIPTION
Fixed the problem with the dropdown below the map, by removing bootstrap's sticky and replacing it with a custom one
<img width="333" alt="Screen Shot 2022-02-24 at 21 25 40" src="https://user-images.githubusercontent.com/39847270/155523657-661fd738-e2c4-4fa9-8d9f-674288d35174.png">
