### PR TITLE
replaced checkboxes with dropdowns for start and end times

### DIFF
--- a/app/assets/stylesheets/components/_booking_form.scss
+++ b/app/assets/stylesheets/components/_booking_form.scss
@@ -1,0 +1,11 @@
+.time-container {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-around;
+  margin-bottom: 12px;
+  select {
+    border-radius: 24px;
+  }
+}
+
+// style="border-radius: 24px;"

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -8,3 +8,4 @@
 @import "map";
 @import "map_marker";
 @import "search_bar";
+@import "booking_form";

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -48,15 +48,9 @@ class BookingsController < ApplicationController
   private
 
   def update_date_params(params)
-    start_time = 0
-    end_time = 0
-    (9..18).each do |time|
-      start_time = time if params["time#{time}"] && start_time == 0
-      end_time = time + 1 if params["time#{time}"]
-    end
     date = params[:booking][:start_date]
-    params[:booking][:start_date] = "#{date}T#{format('%02d', start_time)}:00"
-    params[:booking][:end_date] = "#{date}T#{format('%02d', end_time)}:00"
+    params[:booking][:start_date] = "#{date}T#{format('%02d', params[:start_time])}:00"
+    params[:booking][:end_date] = "#{date}T#{format('%02d', params[:end_time])}:00"
   end
 
   def booking_params

--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -31,6 +31,7 @@ class StudiosController < ApplicationController
   end
 
   def show
+    @booking = Booking.new(start_date: Date.today) # new booking for the form
     @markers = [{ lat: @studio.latitude, lng: @studio.longitude }]
   end
 

--- a/app/javascript/controllers/bookingform_controller.js
+++ b/app/javascript/controllers/bookingform_controller.js
@@ -1,21 +1,35 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["submit"]
+  static targets = ["submit", "startTime", "endTime"]
   static values = { price: Number }
 
   connect() {
     console.log("bookingform_controller connected!");
     this.price_multiplier = 0;
+    this.updatePrice();
   }
   updatePrice(event) {
-    if (event.currentTarget.checked) {
-      this.price_multiplier += 1;
-    } else {
-      this.price_multiplier -= 1;
-    }
+    this.price_multiplier = this.endTimeTarget.value - this.startTimeTarget.value;
 
     console.log(this.price_multiplier)
     this.submitTarget.value = `¥${this.price_multiplier * this.priceValue}`
+  }
+  updateEndTimeSelection(event) {
+    console.log("updateEndTime!!");
+    console.log(event.currentTarget.selectedIndex);
+    const startTime = 10 + event.currentTarget.selectedIndex;
+    this.endTimeTarget.innerHTML = ""
+    for (let i = startTime; i <= 19; i += 1) {
+      if (i <= 12) {
+        this.endTimeTarget.innerHTML += `<option value="${i}" >${i} AM</option>`
+      } else {
+        this.endTimeTarget.innerHTML += `<option value="${i}" >${i-12} PM</option>`
+      }
+    }
+    this.endTimeTarget.innerHTML += ""
+    if (event.currentTarget.selected) {
+      console.log(this.endTimeTarget);
+    }
   }
 }

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -5,49 +5,55 @@
 <% (1..11).each do |num| %>
   <% time_strings << "#{num} PM" %>
 <% end %>
-<%= simple_form_for [studio, booking], data: {controller: "bookingform", bookingform_price_value: studio.price} do |f| %>
+<%= simple_form_for [studio, booking], data: {controller: "bookingform", bookingform_price_value: studio.price}, id: "booking-form" do |f| %>
   <%#= f.input :start_date, html5: true, wrapper_html: {class: 'date-wrapper'}, label: "Time to Start Jamming" %>
   <%= f.input :start_date, as: :date, html5: true, wrapper_html: {class: 'date-wrapper mb-4'}, label: "Date" %>
 
   <%#= f.input :end_date, html5: true, wrapper_html: {class: 'date-wrapper'}, label: "Time to Bro Home" %>
-  <label for="start-time" class="form-label text-white">From</label>
-  <select id="start-time"
-          class="form-select"
-          aria-label="Default select example"
-          data-bookingform-target="startTime"
-          data-action="change->bookingform#updateEndTimeSelection change->bookingform#updatePrice"
-          name="start_time">
-    <%# <option selected>Open this select menu</option> %>
-    <option value="9" >9 AM</option>
-    <option value="10">10 AM</option>
-    <option value="11">11 AM</option>
-    <option value="12">12 AM</option>
-    <option value="13">1 PM</option>
-    <option value="14">2 PM</option>
-    <option value="15">3 PM</option>
-    <option value="16">4 PM</option>
-    <option value="17">5 PM</option>
-    <option value="18">6 PM</option>
-  </select>
+  <div class="time-container">
+    <div>
+      <label for="start-time" class="form-label text-white">From</label>
+      <select id="start-time"
+              class="form-select"
+              aria-label="Default select example"
+              data-bookingform-target="startTime"
+              data-action="change->bookingform#updateEndTimeSelection change->bookingform#updatePrice"
+              name="start_time">
+        <%# <option selected>Open this select menu</option> %>
+        <option value="9" >9 AM</option>
+        <option value="10">10 AM</option>
+        <option value="11">11 AM</option>
+        <option value="12">12 AM</option>
+        <option value="13">1 PM</option>
+        <option value="14">2 PM</option>
+        <option value="15">3 PM</option>
+        <option value="16">4 PM</option>
+        <option value="17">5 PM</option>
+        <option value="18">6 PM</option>
+      </select>
+    </div>
   <%# <input type="number"> %>
 
-  <label for="end-time" class="form-label text-white mt-2">To</label>
-  <select id="end-time"
-          class="form-select"
-          aria-label="Default select example"
-          data-bookingform-target="endTime"
-          data-action="change->bookingform#updatePrice"
-          name="end_time">
-    <option value="10">10 AM</option>
-    <option value="11">11 AM</option>
-    <option value="12">12 AM</option>
-    <option value="13">1 PM</option>
-    <option value="14">2 PM</option>
-    <option value="15">3 PM</option>
-    <option value="16">4 PM</option>
-    <option value="17">5 PM</option>
-    <option value="18">6 PM</option>
-    <option value="19">7 PM</option>
-  </select>
+    <div>
+      <label for="end-time" class="form-label text-white">To</label>
+      <select id="end-time"
+              class="form-select"
+              aria-label="Default select example"
+              data-bookingform-target="endTime"
+              data-action="change->bookingform#updatePrice"
+              name="end_time">
+        <option value="10">10 AM</option>
+        <option value="11">11 AM</option>
+        <option value="12">12 AM</option>
+        <option value="13">1 PM</option>
+        <option value="14">2 PM</option>
+        <option value="15">3 PM</option>
+        <option value="16">4 PM</option>
+        <option value="17">5 PM</option>
+        <option value="18">6 PM</option>
+        <option value="19">7 PM</option>
+      </select>
+    </div>
+  </div>
   <%= f.submit value: "Book now!", class: "studio-booking-btn mx-auto mt-4", data: {bookingform_target: "submit"} %>
 <% end %>

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -10,12 +10,44 @@
   <%= f.input :start_date, as: :date, html5: true, wrapper_html: {class: 'date-wrapper mb-4'}, label: "Date" %>
 
   <%#= f.input :end_date, html5: true, wrapper_html: {class: 'date-wrapper'}, label: "Time to Bro Home" %>
-  <p class="text-white mb-2">Available hourly time slots:</p>
-  <% (9..18).each do |time| %>
-    <div class="d-inline-block mb-0">
-      <input type="checkbox" name=<%= "time#{time}" %> value=<%= "1" %> id=<%= "time#{time}"%> data-action="click->bookingform#updatePrice" class="form-check-input">
-      <label for=<%= "time#{time}" %> class="form-check-label text-white"><%= time_strings[time] %></label>
-    </div>
-  <% end %>
+  <label for="start-time" class="form-label text-white">From</label>
+  <select id="start-time"
+          class="form-select"
+          aria-label="Default select example"
+          data-bookingform-target="startTime"
+          data-action="change->bookingform#updateEndTimeSelection change->bookingform#updatePrice"
+          name="start_time">
+    <%# <option selected>Open this select menu</option> %>
+    <option value="9" >9 AM</option>
+    <option value="10">10 AM</option>
+    <option value="11">11 AM</option>
+    <option value="12">12 AM</option>
+    <option value="13">1 PM</option>
+    <option value="14">2 PM</option>
+    <option value="15">3 PM</option>
+    <option value="16">4 PM</option>
+    <option value="17">5 PM</option>
+    <option value="18">6 PM</option>
+  </select>
+  <%# <input type="number"> %>
+
+  <label for="end-time" class="form-label text-white mt-2">To</label>
+  <select id="end-time"
+          class="form-select"
+          aria-label="Default select example"
+          data-bookingform-target="endTime"
+          data-action="change->bookingform#updatePrice"
+          name="end_time">
+    <option value="10">10 AM</option>
+    <option value="11">11 AM</option>
+    <option value="12">12 AM</option>
+    <option value="13">1 PM</option>
+    <option value="14">2 PM</option>
+    <option value="15">3 PM</option>
+    <option value="16">4 PM</option>
+    <option value="17">5 PM</option>
+    <option value="18">6 PM</option>
+    <option value="19">7 PM</option>
+  </select>
   <%= f.submit value: "Book now!", class: "studio-booking-btn mx-auto mt-4", data: {bookingform_target: "submit"} %>
 <% end %>

--- a/app/views/studios/show.html.erb
+++ b/app/views/studios/show.html.erb
@@ -36,7 +36,9 @@
           </p>
         </div>
         <div>
-          <%= render partial: "bookings/form", locals: {booking: Booking.new, studio: @studio} %>
+          <%= render partial: "bookings/form", locals: {booking: @booking, studio: @studio} %>
+
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
I replaced the checkboxes with two dropdown menus to select the start and end times. I added some JS to ensure that only end times at least one hour after the start time can be selected.

<img width="437" alt="Screen Shot 2022-02-25 at 8 28 16" src="https://user-images.githubusercontent.com/39847270/155624681-3ece5c09-7d21-4be8-a86c-0290b23fdf22.png">
